### PR TITLE
Update peerDependency to support stylelint v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "stylelint": "^9.0.0"
   },
   "peerDependencies": {
-    "stylelint": ">=8.4.0 || <10.0.0"
+    "stylelint": ">=8.4.0 <10.0.0"
   },
   "eslintConfig": {
     "env": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "stylelint": "^9.0.0"
   },
   "peerDependencies": {
-    "stylelint": "^8.4.0"
+    "stylelint": ">=8.4.0 || <10.0.0"
   },
   "eslintConfig": {
     "env": {


### PR DESCRIPTION
I tested and verified that it still works with v9.
Prevents `Unmet peerDependency` warnings from npm.